### PR TITLE
Added explanation for detached HEAD

### DIFF
--- a/branches.md
+++ b/branches.md
@@ -122,6 +122,7 @@ So it changed the current branch, which is stored in the `HEAD` file.
 
 > How would you swap the two `master` and `hello` branches around[?](explanation/branches_swap.md)
 
+> We've seen that the `git checkout` command can be used to checkout branches which are just references to commits. Can `git checkout` command be used to checkout commits directly? What happens to `ref/heads` and `.git/HEAD` if this is the case[?](explanation/detached_state.md)
 
 
 Next

--- a/explanation/branches_manual_head.md
+++ b/explanation/branches_manual_head.md
@@ -30,7 +30,7 @@ something
 
 So in my case I was on the `master` branch, and manually switching
 to `hello` (obviously) didn't update the working files magically.
-That's something you neeed `checkout` for.
+That's something you need `checkout` for.
 
 So in some ways you can think of `checkout` as two operations:
 

--- a/explanation/detached_state.md
+++ b/explanation/detached_state.md
@@ -1,0 +1,87 @@
+> We've seen that the `git checkout` command can be used to checkout branches which are just references to commits. Can `git checkout` command be used to checkout commits directly? What happens to `ref/heads` if this is the case?
+
+Git certainly does let us checkout commits directly. As an example we can checkout our second commit as follows:
+
+```sh
+> git checkout 672e562
+
+Note: switching to '672e562'.
+
+You are in 'detached HEAD' state. You can look around, make experimental
+changes and commit them, and you can discard any commits you make in this
+state without impacting any branches by switching back to a branch.
+
+HEAD is now at 672e562 Second commit
+
+> git log --graph --oneline --decorate --all
+
+* 41ce7fa (master) Third commit
+* 672e562 (HEAD, hello) Second commit
+* 406bb3b Initial commit
+```
+
+Notice, there's no arrow pointing to from `HEAD` to our `hello` branch in our log (which usually happens when we checkout a **branch**). Interestingly, no knew reference is created in the `.git/refs/heads` although `.git/HEAD` is still updated to reflect this new change. However instead of pointing to a reference of a branch, it refers directly to the commit we checked out.
+
+```sh
+> ls -F .git/refs/heads
+
+hello   master
+
+> cat .git/HEAD
+
+672e5628856f61c36e5671cd2d2c5789149a1538
+```
+
+As alluded to by the `git checkout` message from above, this is know as a _detached HEAD state_. Surprisingly, we can actually create commits in a detached HEAD state.
+
+```sh
+> echo "hello experiment" >> file.txt
+
+> git add .
+
+> git commit -m "Experimental change"
+
+[detached HEAD 1fcdb7e] Experimental change
+ 1 file changed, 1 insertion(+)
+
+> git log --graph --oneline --decorate --all
+
+* 1fcdb7e (HEAD) Experimental change
+| * 41ce7fa (master) Third commit
+|/
+* 672e562 (hello) Second commit
+* 406bb3b Initial commit
+```
+
+The caveat is, if we want git to remember these changes, we need to create a new branch for them.
+
+```sh
+> git branch experimental
+
+> git log --graph --oneline --decorate --all
+
+* 1fcdb7e (HEAD, experimental) Experimental change
+| * 41ce7fa (master) Third commit
+|/
+* 672e562 (hello) Second commit
+* 406bb3b Initial commit
+```
+
+To move out of a detached HEAD state, all we need to do is checkout any branch within our repository.
+
+```sh
+> git checkout master
+
+Previous HEAD position was 1fcdb7e Experimental change
+Switched to branch 'master'
+
+> git log --graph --oneline --decorate --all
+
+* 1fcdb7e (experimental) Experimental change
+| * 41ce7fa (HEAD -> master) Third commit
+|/
+* 672e562 (hello) Second commit
+* 406bb3b Initial commit
+```
+
+Notice, that the arrow from our `HEAD` to our checked out branch appears once again in our log.


### PR DESCRIPTION
## Motivation
- Detached HEAD states are a common pain point a many new users starting out in git. This section should hopefully give them a better understanding of what it is and how to "fix" it.
- This was actually my first time digging around the `.git` folder and I was kinda just interest in how the internal git files responded to a detached HEAD state.

## Testing
- Played around with the new changes locally to make sure links work/everything looks nice